### PR TITLE
Placeholder allowed in tab name. Integer attributes allowed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "TabExtension",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Mendix Widget: Extends the Mendix tab with some nice features.",
   "author": "Andries Smit <andries.smit@flockofbirds.org>",
   "main": "Gruntfile.js",

--- a/src/TabExtension/TabName.js
+++ b/src/TabExtension/TabName.js
@@ -51,8 +51,15 @@ define(["dojo/_base/declare", "dojo/query", "dojo/dom-attr",
                     var tabList = query(".mx-tabcontainer-tabs li a", tabWidget);
                     var tab = tabList[tabIndex];
                     if (tab) {
+                        // Store original title [Axel Brink 2016-08-19]
+                        var origcaption = domAttr.get(tab, "origcaption");
+                        if (!origcaption) {
+                            origcaption = tab.innerHTML;
+                            domAttr.set(tab, "origcaption", origcaption);
+                        }
+
                         if (value) {
-                            tab.innerHTML = value;
+                            tab.innerHTML = origcaption.replace("\{1\}", value);
                         } else {
                             tab.innerHTML = this.emptyValue;
                         }

--- a/src/TabExtension/TabName.xml
+++ b/src/TabExtension/TabName.xml
@@ -17,9 +17,11 @@
         <property key="attribute" type="attribute">
             <caption>Attribute</caption>
             <category>Data source</category>
-            <description>The attribute that will set the name of the Tab Title.</description>
+            <description>The attribute that will set the name of the Tab Title. If the original tab caption contains '{1}', only that part will be replaced.</description>
             <attributeTypes>
                 <attributeType name="String"/>
+                <attributeType name="Integer"/>
+                <attributeType name="Long"/>
             </attributeTypes>
         </property>
     </properties>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Tab Extension" version="2.1" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Tab Extension" version="2.2" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="TabExtension/TabName.xml"/>
             <widgetFile path="TabExtension/TabButton.xml"/>


### PR DESCRIPTION
As discussed, this change makes it possible to use one placeholder in tab captions. It also adds the possibility to map integer attributes. Version number increased.
Please note that I was not able to compile this project using Grunt so a review is needed.